### PR TITLE
BUGFIX: Remove duplicate source funding

### DIFF
--- a/js/stripe-wdc.js
+++ b/js/stripe-wdc.js
@@ -110,10 +110,6 @@ var DataTools = (function() {
 		fieldnames.push('source_object');
 		fieldtypes.push('string');
 
-		// Add in 'source_funding' field
-		fieldnames.push('source_funding');
-		fieldtypes.push('string');
-
 		// Add in 'source_last4' field
 		fieldnames.push('source_last4');
 		fieldtypes.push('string');


### PR DESCRIPTION
Bugfix: source_funding was listed twice in fieldnames, removed one of the entries.
Code would not work with both entries.

+1 @benjisg 
